### PR TITLE
I-9: Fix defect: If you start the Docker apps a second time, geth empts because it tries to already existing accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# geth-poa-testnet
+# Fork note
 
-[![](https://images.microbadger.com/badges/version/ulamlabs/geth-poa-testnet.svg)](https://microbadger.com/images/ulamlabs/geth-poa-testnet "Get your own version badge on microbadger.com")
+This is a fork of [geth-poa-testnet](https://github.com/ulamlabs/geth-poa-testnet) tailored to the needs of [minimal crypto exchange](https://github.com/mentiflectax/minimal-crypto-exchange).
+
+For issues see [this page](https://github.com/mentiflectax/minimal-crypto-exchange/issues).
+
+# geth-poa-testnet
 
 Docker image for Ethereum testnet using proof-of-authority consensus protocol. By default two accounts will be created, one serving as a signer and another one which holds all the coins on the testnet.
 
@@ -9,7 +13,7 @@ GitHub Repository is available at [ulamlabs/geth-poa-testnet](https://github.com
 ## Building
 
 ```console
-$ docker build -t ulamlabs/geth-poa-testnet:latest .
+$ docker build -t mentiflectax/geth-poa-testnet:latest .
 ```
 
 ## Usage

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,8 +23,28 @@ echo $ETH_PRIVATE_KEY > /tmp/eth_private_key
 geth --datadir /data init ./.genesis.json
 geth --datadir /data account import --password /tmp/eth_pass /tmp/eth_private_key || true
 
+#
+# Create buffer account (start)
+# 
+echo carsdrivefasterbecausetheyhavebrakes > /tmp/buffer_pass
+echo 766df34218d5a715018d54789d6383798a1885088d525670802ed8cf152db5b4 > /tmp/buffer_private_key
+geth account import --datadir /data --password /tmp/buffer_pass /tmp/buffer_private_key
+#
+# Create buffer account (end)
+#
+
+#
+# Create exchange account (start)
+# 
+echo a-turkey-is-a-chicken-designed-by-a-committee > /tmp/exchange_pass
+echo b07aedf303f832664eb7a5295be737776cb1ad17a277ec287b3b3c7bac154e5e > /tmp/exchange_private_key
+geth account import --datadir /data  --password /tmp/exchange_pass  /tmp/exchange_private_key
+#
+# Create exchange account (end)
+# 
+
 if [[ $# -eq 0 ]] ; then
-  exec geth --config .config.toml --allow-insecure-unlock --nousb --verbosity $ETH_VERBOSITY --gcmode=archive --mine --miner.threads 1 --unlock $ETH_ADDRESS --password /tmp/eth_pass
+  exec geth --config .config.toml --allow-insecure-unlock --nousb --verbosity $ETH_VERBOSITY --gcmode=archive --mine --miner.threads 1 --unlock $ETH_ADDRESS --password /tmp/eth_pass --rpcapi="db,eth,net,web3,personal"
 else
   exec "$@"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ geth --datadir /data account import --password /tmp/eth_pass /tmp/eth_private_ke
 # 
 echo carsdrivefasterbecausetheyhavebrakes > /tmp/buffer_pass
 echo 766df34218d5a715018d54789d6383798a1885088d525670802ed8cf152db5b4 > /tmp/buffer_private_key
-geth account import --datadir /data --password /tmp/buffer_pass /tmp/buffer_private_key
+geth account import --datadir /data --password /tmp/buffer_pass /tmp/buffer_private_key || true
 #
 # Create buffer account (end)
 #
@@ -38,7 +38,7 @@ geth account import --datadir /data --password /tmp/buffer_pass /tmp/buffer_priv
 # 
 echo a-turkey-is-a-chicken-designed-by-a-committee > /tmp/exchange_pass
 echo b07aedf303f832664eb7a5295be737776cb1ad17a277ec287b3b3c7bac154e5e > /tmp/exchange_private_key
-geth account import --datadir /data  --password /tmp/exchange_pass  /tmp/exchange_private_key
+geth account import --datadir /data  --password /tmp/exchange_pass  /tmp/exchange_private_key || true
 #
 # Create exchange account (end)
 # 


### PR DESCRIPTION
[Issue](https://github.com/mentiflectax/minimal-crypto-exchange/issues/9)